### PR TITLE
Define xrange() for Python 3

### DIFF
--- a/util/util.py
+++ b/util/util.py
@@ -7,6 +7,12 @@ import numpy as np
 import os
 import collections
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 # Converts a Tensor into a Numpy array
 # |imtype|: the desired type of the converted numpy array
 def tensor2im(image_tensor, imtype=np.uint8):


### PR DESCRIPTION
The same change would need to be made to 4 other files...

flake8 testing of https://github.com/jessemelpolio/non-stationary_texture_syn on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./util/util.py:14:14: F821 undefined name 'xrange'
    for i in xrange(image_tensor.shape[0]):
             ^
./util/visualizer.py:83:28: F821 undefined name 'xrange'
                for col in xrange(batchsize):
                           ^
./util/pynoise/hammersley.py:15:53: F821 undefined name 'xrange'
    points = [(generate_point(base, i), i) for i in xrange(total)]
                                                    ^
./util/pynoise/perlin.py:26:18: F821 undefined name 'xrange'
        for i in xrange(self.octaves):
                 ^
./util/pynoise/test.py:7:10: F821 undefined name 'xrange'
for x in xrange(500):
         ^
./util/pynoise/test.py:8:14: F821 undefined name 'xrange'
    for y in xrange(500):
             ^
6     F821 undefined name 'xrange'
6
```